### PR TITLE
Remove viewer_template_flip.html from output directory

### DIFF
--- a/PotreeConverter/src/PotreeConverter.cpp
+++ b/PotreeConverter/src/PotreeConverter.cpp
@@ -173,6 +173,7 @@ void PotreeConverter::generatePage(string name){
 
     Potree::copyDir(fs::path(templateDir), fs::path(pagedir));
 	fs::remove(pagedir + "/viewer_template.html");
+	fs::remove(pagedir + "/viewer_template_flip.html");
 	fs::remove(pagedir + "/lasmap_template.html");
 
 	if(!this->sourceListingOnly){ // change viewer template


### PR DESCRIPTION
Apparently the superfluous `html` template files were already being removed from the output directory one by one in the code, so I have simply added a line to remove `viewer_template_flip.html` as well.

It is not very clean, but that's how the code works.