### PR TITLE
Remove extension-less files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,15 @@
-Potree.v11.suo
-Potree.v12.suo
-Potree.sdf
-PotreeConverter/bin
-PotreeConverter/obj
-Potree.opensdf
-bin/
-obj
-build/*
-.idea
-*.orig
-test/converted
-*.o
-*.a
+# Taken from https://gist.github.com/chichunchen/970a7e97c74a253a4503
+
+# Ignore all
+*
+
+# Unignore all with extensions
+!*.*
+
+# Unignore all dirs
+!*/
+
+### Above combination will ignore all files without extension ###
+
+*.[a,o]
+build/


### PR DESCRIPTION
Simplify the `.gitignore` and make it ignore all files resulting from the build.

With the previous `.gitignore`, these files were not ignored, and thus showing up in `git status`:
```
LAStools/LASzip/build/
LAStools/src/las2las
LAStools/src/las2txt
LAStools/src/lasdiff
LAStools/src/lasindex
LAStools/src/lasinfo
LAStools/src/lasmerge
LAStools/src/lasprecision
LAStools/src/laszip
LAStools/src/txt2las
```