### PR TITLE
[fix] Non-deterministic CLI behavior

### DIFF
--- a/PotreeConverter/lib/arguments/arguments.hpp
+++ b/PotreeConverter/lib/arguments/arguments.hpp
@@ -283,14 +283,15 @@ public:
 
 	AValue get(string name) {
 		Argument *arg = getArgument(name);
+		vector<string> values;
 
 		for (auto entry : map) {
 			if (arg->is(entry.first)) {
-				return AValue(entry.second);
+				values.insert(values.end(), entry.second.begin(), entry.second.end());
 			}
 		}
 
-		return AValue({});
+		return AValue(values);
 	}
 
 

--- a/PotreeConverter/src/main.cpp
+++ b/PotreeConverter/src/main.cpp
@@ -221,6 +221,11 @@ PotreeArguments parseArguments(int argc, char **argv){
 		}
 	}
 
+	if (a.source.empty()) {
+		cerr << "No input files specified" << endl;
+		exit(1);
+	}
+
 	a.title = args.get("title").as<string>();
 	a.description = args.get("description").as<string>();
 	a.edlEnabled = args.has("edl-enabled");


### PR DESCRIPTION
Without this patch, `PotreeConverter` sometimes crashes with a segfault depending on how you pass it command-line arguments.

This patch was taken from https://github.com/potree/PotreeConverter/pull/335 which unfortunately hasn't been looked at by the project maintainer even though it was opened in 2018...